### PR TITLE
Update migrate to flowWithLifecycle

### DIFF
--- a/app/src/main/java/com/ragvax/dictionary/ui/definition/DefinitionFragment.kt
+++ b/app/src/main/java/com/ragvax/dictionary/ui/definition/DefinitionFragment.kt
@@ -43,7 +43,7 @@ class DefinitionFragment : Fragment(R.layout.fragment_definition) {
     }
 
     private fun observeViewModel() {
-        viewModel.definitionFlow.collectWhileStarted(viewLifecycleOwner) { state ->
+        viewModel.definitionFlow.observeWithLifecycle(viewLifecycleOwner) { state ->
             when (state) {
                 is DefinitionState.Success -> bindOnSuccess(state.definition)
                 is DefinitionState.Failure -> bindOnFailure(state.errorTitle, state.errorMsg)

--- a/app/src/main/java/com/ragvax/dictionary/ui/definition/adapters/DefinitionAdapter.kt
+++ b/app/src/main/java/com/ragvax/dictionary/ui/definition/adapters/DefinitionAdapter.kt
@@ -3,7 +3,6 @@ package com.ragvax.dictionary.ui.definition.adapters
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.ragvax.dictionary.data.source.remote.Definition
 import com.ragvax.dictionary.databinding.ItemDefinitionBinding
 import com.ragvax.dictionary.domain.model.WordDefinition
 import com.ragvax.dictionary.utils.hide

--- a/app/src/main/java/com/ragvax/dictionary/ui/definition/adapters/MeaningAdapter.kt
+++ b/app/src/main/java/com/ragvax/dictionary/ui/definition/adapters/MeaningAdapter.kt
@@ -7,7 +7,6 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.ragvax.dictionary.data.source.remote.Meaning
 import com.ragvax.dictionary.databinding.ItemMeaningBinding
 import com.ragvax.dictionary.domain.model.WordDefinition
 import com.ragvax.dictionary.utils.hide

--- a/app/src/main/java/com/ragvax/dictionary/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ragvax/dictionary/ui/home/HomeFragment.kt
@@ -14,11 +14,10 @@ import androidx.recyclerview.widget.RecyclerView
 import com.ragvax.dictionary.R
 import com.ragvax.dictionary.databinding.FragmentHomeBinding
 import com.ragvax.dictionary.ui.home.adapters.RecentSearchesAdapter
-import com.ragvax.dictionary.utils.collectWhileStarted
+import com.ragvax.dictionary.utils.observeWithLifecycle
 import com.ragvax.dictionary.utils.hideKeyboard
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.collectLatest
 
 @AndroidEntryPoint
 class HomeFragment : Fragment(R.layout.fragment_home),
@@ -73,7 +72,7 @@ class HomeFragment : Fragment(R.layout.fragment_home),
     }
 
     private fun observeViewModel() {
-        viewModel.homeEvent.collectWhileStarted(viewLifecycleOwner) { event ->
+        viewModel.homeEvent.observeWithLifecycle(viewLifecycleOwner) { event ->
             when (event) {
                 is HomeEvent.NavigateToDefinition -> {
                     val action = HomeFragmentDirections.actionHomeFragmentToDefinitionFragment(event.query)

--- a/app/src/main/java/com/ragvax/dictionary/utils/FlowObserverExt.kt
+++ b/app/src/main/java/com/ragvax/dictionary/utils/FlowObserverExt.kt
@@ -1,33 +1,17 @@
 package com.ragvax.dictionary.utils
 
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.*
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
-inline fun <reified T> Flow<T>.collectWhileStarted(
+inline fun <reified T> Flow<T>.observeWithLifecycle(
     lifecycleOwner: LifecycleOwner,
+    minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
     noinline action: suspend (T) -> Unit
-) {
-    object : DefaultLifecycleObserver {
-        private var job: Job? = null
-
-        init {
-            lifecycleOwner.lifecycle.addObserver(this)
-        }
-
-        override fun onStart(owner: LifecycleOwner) {
-            job = owner.lifecycleScope.launch {
-                collect { action(it) }
-            }
-        }
-
-        override fun onStop(owner: LifecycleOwner) {
-            job?.cancel()
-            job = null
-        }
+): Job {
+    return lifecycleOwner.lifecycleScope.launch {
+        flowWithLifecycle(lifecycleOwner.lifecycle, minActiveState).collect(action)
     }
 }


### PR DESCRIPTION
Migrate to a safer way to collect flow with _flowWithLifecycle_ from UIs. This avoids any boilerplate code since the associated code to cancel the coroutine when it’s no longer needed.